### PR TITLE
Don't count on theme words being in "solutions" array

### DIFF
--- a/ts/board.ts
+++ b/ts/board.ts
@@ -7,7 +7,7 @@ export class BoardData {
     clue: string;
     startingBoard: string[];
     solutions: string[];
-    themeCoords: { [theme: string]: number[][] }; // number[2][]
+    themeCoords: { [theme: string]: Array<[number, number]> };
 }
 
 export function BoardCredits(board: BoardData): string {
@@ -33,6 +33,7 @@ export const defaultBoard: BoardData = {
     printDate: "2024-05-24",
     id: -1,
     editor: "Harvey Tindall",
+    constructors: "Harvey Tindall",
     spangram: "ALRIGHTY",
     clue: "(Down)load a game below to start.",
     startingBoard: [

--- a/ts/main.ts
+++ b/ts/main.ts
@@ -405,7 +405,8 @@ class GameBoard {
     // 0 = Invalid. 1 = Valid word, you get a point towards hints. 2 = Valid theme word, 3 = Valid spangram.
     private validateGuess(word: string): number {
         let ret = 0;
-        if (this._board.solutions.includes(word)) ret += 1;
+        // Theme words are sometimes not in "solutions", so check for both
+        if (this._board.themeCoords[word] || this._board.solutions.includes(word)) ret += 1;
         // Spangram is sometimes a combination of multiple "solutions", so might not be in the list as-is.
         // else return ret;
         if (this._board.spangram == word) {


### PR DESCRIPTION
Theme words may not appear in the "solutions" array (example: 2025-04-07, "jackalope"). In these cases, trying to enter the theme word will result in an "incorrect" guess, preventing finishing the board. This change counts all theme words as "solutions" to remediate that issue.

Note that this implementation will have the side-effect of considering theme words as solutions when the theme word being entered is not in the correct position. As I have no way to verify this behavior on NYT's official implementation, I implemented this based on my own opinions on how I believe that should work. There is another possible behavior, where guesses that aren't "solutions", but are "theme words" in an incorrect position would be treated as failed guesses; if that's the behavior you'd rather see, simply check if the word is a solution when "coordsMatch" returns false, and if not, return 0.